### PR TITLE
Supporting lists and dict comprehensions

### DIFF
--- a/mypyrun.py
+++ b/mypyrun.py
@@ -71,6 +71,9 @@ _FILTERS = [
      '".*" defined the type as "None"\)'),
     # Other:
     ('incompatible_list_comprehension', 'List comprehension has incompatible type'),
+    ('incompatible_dict_comprehension', '(Key|Value) expression in dictionary comprehension has incompatible type'),
+    ('incompatible_list_item', 'List item \d+ has incompatible type'),
+    ('incompatible_dict_entry', 'Dict entry \d+ has incompatible type'),
     ('cannot_assign_to_method', 'Cannot assign to a method'),
     ('not_enough_arguments', 'Too few arguments'),
     ('not_callable', ' not callable'),


### PR DESCRIPTION
A few type errors are missed.

eg:

```py
from typing import Sequence, Dict

def dict_sum(dct): # type: (Dict[str, int]) -> int
    return sum(dct.values())

def list_sum(lst): # type: (Sequence[int]) -> int
    return sum(lst)

dict_sum({a:b for a,b in [(123, "123")]})
list_sum(["123"])
```