### PR TITLE
win32 color support using colorama

### DIFF
--- a/mypyrun.py
+++ b/mypyrun.py
@@ -18,6 +18,10 @@ except ImportError:
 if False:
     from typing import *
 
+if sys.platform == 'win32':
+    from colorama import init
+    init() 
+
 # adapted from mypy:
 CONFIG_FILE = 'mypyrun.ini'
 SHARED_CONFIG_FILES = ('mypy.ini', 'setup.cfg')

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     entry_points={
         'console_scripts': ['mypyrun=mypyrun:main'],
     },
-    install_requires=['configparser'],
+    install_requires=['configparser', 'colorama'],
     extras_require={
         "tests": [
             "coverage",


### PR DESCRIPTION
Added support for colors on Windows using module colorama imported only on Windows machines.

`pip install colorama`