### PR TITLE
Complex filtering

### DIFF
--- a/mypyrun.py
+++ b/mypyrun.py
@@ -88,6 +88,9 @@ _FILTERS = [
     ('invalid_return_assignment', 'does not return a value'),
     ('unsupported_operand', 'Unsupported .*operand '),
     ('abc_with_abstract_attr', "Cannot instantiate abstract class .* with abstract attribute"),
+
+    # Anything we missed
+    ("uncategorized", ".+"),
 ]
 
 FILTER_GROUPS = {
@@ -151,7 +154,6 @@ FILTER_GROUPS_REV = {f: g for g, fs in FILTER_GROUPS.items() for f in fs}
 COLORS = {
     'error': 'red',
     'warning': 'yellow',
-    'unhandled': 'white',
     'note': None,
 }
 
@@ -434,7 +436,7 @@ def run(active_files, global_options, module_options):
         last_error = global_options, filename, lineno, msg, error_code
 
         if status == 'error':
-            new_status = options.get_status(error_code, msg) if error_code else 'unhandled'
+            new_status = options.get_status(error_code, msg)
             if new_status == 'error':
                 errors[filename] += 1
             elif new_status == 'warning':

--- a/mypyrun.py
+++ b/mypyrun.py
@@ -90,8 +90,59 @@ _FILTERS = [
     ('abc_with_abstract_attr', "Cannot instantiate abstract class .* with abstract attribute"),
 ]
 
+FILTER_GROUPS = {
+    'env': {
+        'missing_module',
+    },
+    'code': {
+        'invalid_syntax',
+        'wrong_number_of_args',
+        'misplaced_annotation',
+        'not_defined',
+        'invalid_type_arguments',
+        'generator_expected',
+        'orphaned_overload',
+        'already_defined',
+        'need_annotation',
+    },
+    'signature': {
+        'return_expected',
+        'return_not_expected',
+        'incompatible_return',
+        'incompatible_yield',
+        'incompatible_arg',
+        'incompatible_default_arg',
+        'incompatible_subclass_signature',
+        'incompatible_subclass_return',
+        'incompatible_subclass_arg',
+        'incompatible_subclass_attr',
+    },
+    'usage': {
+        'no_attr_none_case',
+        'incompatible_subclass_attr_none_case'
+        'incompatible_list_comprehension',
+        'incompatible_dict_comprehension',
+        'incompatible_list_item',
+        'incompatible_dict_entry',
+        'cannot_assign_to_method',
+        'not_enough_arguments',
+        'not_callable',
+        'no_attr',
+        'not_indexable',
+        'invalid_index',
+        'not_iterable',
+        'not_assignable_by_index',
+        'no_matching_overload',
+        'incompatible_assignment',
+        'invalid_return_assignment',
+        'unsupported_operand',
+        'abc_with_abstract_attr',
+    },
+}
+
 FILTERS = [(n, re.compile(s)) for n, s in _FILTERS]
 FILTERS_SET = frozenset(n for n, s in FILTERS)
+
 
 COLORS = {
     'error': 'red',
@@ -552,9 +603,14 @@ def _regex_list(s):
 
 def _error_set(s):
     # type: (multi_options) -> Optional[Set[str]]
-    result = set(_parse_multi_options(s))
-    if '*' in result:
-        return None
+    result = set()
+    for res in _parse_multi_options(s):
+        if res == '*':
+            return None
+        elif res in FILTER_GROUPS:
+            result |= FILTER_GROUPS[res]
+        else:
+            result.add(res)
     return result
 
 


### PR DESCRIPTION
Just adding a little more options to the error catching. For instance, before you couldn't convert a specific error to a warning, without also selecting some errors.

Also adding some error grouping for easier configuration.

Finally, unifying the cli options with the config ones. ie * wasn't treated as ALL in the cli, and warnings were comma separated but not selects / ignores in the cli.

Thanks for making this thing, by the way! I'm trying to get typing buyin on a large existing code base, and this tool is really going to help. :)